### PR TITLE
fix(http): cookie does not work due to lowercase header of http2

### DIFF
--- a/packages/taro-plugin-http/src/runtime/XMLHttpRequest.ts
+++ b/packages/taro-plugin-http/src/runtime/XMLHttpRequest.ts
@@ -262,7 +262,7 @@ export class XMLHttpRequest extends Events {
 
     if (ENABLE_COOKIE) {
       // 处理 set-cookie
-      const setCookieStr = header['Set-Cookie']
+      const setCookieStr = header['Set-Cookie'] || header['set-cookie']
 
       if (setCookieStr && typeof setCookieStr === 'string') {
         let start = 0


### PR DESCRIPTION

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

http插件在启用cookie时，会从http响应获取`Set-Cookie`，但在http/2约束所有header使用小写字母，导致cookie无法工作，这个pr支持在找不到`Set-Cookie`时尝试查找`set-cookie`

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue: fix #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] 所有小程序
- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 字节跳动小程序
- [ ] QQ 轻应用
- [ ] 京东小程序
- [ ] 快应用平台（QuickApp）
- [ ] Web 平台（H5）
- [ ] 移动端（React-Native）
- [ ] 鸿蒙（harmony）
